### PR TITLE
Calculator issues resolved

### DIFF
--- a/skywizz/cogs/calculator_commands.py
+++ b/skywizz/cogs/calculator_commands.py
@@ -36,16 +36,20 @@ class CalculatorCommands(commands.Cog):
                 num = float(arg)
                 valid_numbers.append(num)
             except ValueError:
-                pass
+                error_embed = skywizz.messages.invalid_argument(given_arg=args,
+                                                                valid_args=
+                                                                '5, 4, 10, ...')
+                await ctx.send(embed=error_embed)
+                return
 
-        if not valid_numbers:
-            error_embed = skywizz.messages.invalid_argument(given_arg=args,
-                                                            valid_args=
-                                                            '5, 4, 10, ...')
-            await ctx.send(embed=error_embed)
-            return
-        else:
-            text = str(sum(valid_numbers))
+        # if not valid_numbers:
+        #     error_embed = skywizz.messages.invalid_argument(given_arg=args,
+        #                                                     valid_args=
+        #                                                     '5, 4, 10, ...')
+        #     await ctx.send(embed=error_embed)
+        #     return
+        # else:
+        text = str(sum(valid_numbers))
         embed = embd.newembed(title='Sum Result',
                               description=f'{ctx.author.mention} {text}')
         await ctx.send(embed=embed)

--- a/skywizz/cogs/calculator_commands.py
+++ b/skywizz/cogs/calculator_commands.py
@@ -42,13 +42,6 @@ class CalculatorCommands(commands.Cog):
                 await ctx.send(embed=error_embed)
                 return
 
-        # if not valid_numbers:
-        #     error_embed = skywizz.messages.invalid_argument(given_arg=args,
-        #                                                     valid_args=
-        #                                                     '5, 4, 10, ...')
-        #     await ctx.send(embed=error_embed)
-        #     return
-        # else:
         text = str(sum(valid_numbers))
         embed = embd.newembed(title='Sum Result',
                               description=f'{ctx.author.mention} {text}')

--- a/skywizz/cogs/calculator_commands.py
+++ b/skywizz/cogs/calculator_commands.py
@@ -76,16 +76,13 @@ class CalculatorCommands(commands.Cog):
                 num = float(arg)
                 valid_numbers.append(num)
             except ValueError:
-                pass
+                error_embed = skywizz.messages.invalid_argument(given_arg=args,
+                                                                valid_args=
+                                                                '5, 4, 10, ...')
+                await ctx.send(embed=error_embed)
+                return
 
-        if not valid_numbers:
-            error_embed = skywizz.messages.invalid_argument(given_arg=args,
-                                                            valid_args=
-                                                            '5, 4, 10, ...')
-            await ctx.send(embed=error_embed)
-            return
-        else:
-            text = str(tools.product(valid_numbers))
+        text = str(tools.product(valid_numbers))
         embed = embd.newembed(title='Product Result',
                               description=f'{ctx.author.mention} {text}')
         await ctx.send(embed=embed)

--- a/skywizz/cogs/calculator_commands.py
+++ b/skywizz/cogs/calculator_commands.py
@@ -109,17 +109,13 @@ class CalculatorCommands(commands.Cog):
                 num = float(arg)
                 valid_numbers.append(num)
             except ValueError:
-                pass
+                error_embed = skywizz.messages.invalid_argument(given_arg=args,
+                                                                valid_args=
+                                                                '5, 4, 10, ...')
+                await ctx.send(embed=error_embed)
+                return
 
-        if not valid_numbers:
-            error_embed = skywizz.messages.invalid_argument(given_arg=args,
-                                                            valid_args=
-                                                            '5, 4, 10, ...')
-            await ctx.send(embed=error_embed)
-            return
-        else:
-            text = str(tools.subtract(valid_numbers))
-
+        text = str(tools.subtract(valid_numbers))
         embed = embd.newembed(title='Subtraction Result',
                               description=f'{ctx.author.mention} {text}')
 


### PR DESCRIPTION
Previously if you mixed numbers with strings, the arguments were accepted and the numbers calculated. Now, calculator doesn't accept any argument that can't be casted to float. 